### PR TITLE
feat(bot): refactor Discord bot to use rig-core agent framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.15",
  "retainer",
+ "rig-core",
  "rspotify",
  "serde",
  "serde_json",
@@ -155,6 +156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
 name = "async-lock"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -213,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1055,6 +1062,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "either"
@@ -2349,6 +2362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3004,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
+name = "rig-core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90771abe32248301b0f95ca4e8a30122e0471b7b778700ca6fd563d3e568e472"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "glob",
+ "mime_guess",
+ "ordered-float",
+ "reqwest 0.12.15",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.63",
+ "tracing",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3299,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "scoped-futures"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,6 +3436,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -38,6 +38,7 @@ const_format = "0.2.34"
 futures = "0.3.31"
 article_scraper = "2.1.2"
 url = "2.5.4"
+rig-core = "0.13.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/api/src/discord/bot.rs
+++ b/api/src/discord/bot.rs
@@ -1,195 +1,259 @@
-use async_openai::{
-    config::OpenAIConfig,
-    types::{
-        ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
-        ChatCompletionRequestMessageContentPartImage, ChatCompletionRequestMessageContentPartText,
-        ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
-        ChatCompletionRequestUserMessageContentPart, CreateChatCompletionRequestArgs, ImageUrl,
-        ReasoningEffort,
-    },
-    Client as OpenAIClient,
-};
 use const_format::formatcp;
-use eyre::Context as _;
-use futures_util::StreamExt;
-use regex::Regex;
-use serenity::all::{ChannelId, CreateMessage, Message, Ready, Typing};
+use rig::prelude::*;
+use rig::{
+    agent::Agent,
+    completion::{Message as RigMessage, Prompt, ToolDefinition},
+    message::{ImageDetail, UserContent},
+    providers::openai,
+    tool::Tool,
+    OneOrMany,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serenity::all::{ChannelId, CreateMessage, Message, Ready};
 use serenity::async_trait;
+use serenity::futures::StreamExt;
 use serenity::prelude::*;
 use std::{
-    sync::{atomic::AtomicBool, LazyLock},
-    time::Duration,
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
 };
+use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing;
 
 const WHITELIST_CHANNELS: [u64; 2] = [1133997981637554188, 1119652436102086809];
-const MESSAGE_CONTEXT_SIZE: usize = 30;
-const LAYER1_MODEL: &str = "gpt-4.1-mini";
-const LAYER2_MODEL: &str = "o4-mini";
-const LAYER1_TEMPERATURE: f32 = 0.3;
-#[allow(dead_code)]
-const LAYER2_TEMPERATURE: f32 = 0.75;
-const LAYER1_MAX_TOKENS: u16 = 300;
-#[allow(dead_code)]
-const LAYER2_MAX_TOKENS: u16 = 4096;
-const RESPONSE_THRESHOLD: i32 = 8;
+const MESSAGE_CONTEXT_SIZE: usize = 20; // Number of previous messages to load for context
+const MESSAGE_DEBOUNCE_TIMEOUT_MS: u64 = 5000; // 5 seconds to collect messages
 const URL_FETCH_TIMEOUT_SECS: Duration = Duration::from_secs(15);
-const MAX_REF_MSG_LEN: usize = 50; // Max length for referenced message preview
-const MAX_ASSISTANT_RESPONSE_MESSAGE_COUNT: usize = 1;
 const DISCORD_BOT_NAME: &str = "The Irony Himself";
+const MAX_AGENT_TURNS: usize = 10; // Maximum turns for multi-turn reasoning
+const AGENT_SESSION_TIMEOUT_MINS: u64 = 30; // Reset agent after 30 minutes of inactivity
 
-// Regex to remove timestamp and author prefix and context if the bot accidentally outputs it
-static CLEAN_MESSAGE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?xms) # Enable comments, insignificant whitespace, multiline mode, and dotall mode
-        # --- Option 1: Generic Timestamp/Author prefix at the START of the string ---
-        (
-            ^           # Anchor to the beginning of the entire string
-            \[          # Literal opening bracket
-            .*?         # *ANY* character (.), matched 0+ times (*), non-greedily (?)
-                        # This will match everything inside the brackets, regardless of format
-            \]          # Literal closing bracket
-            \s+         # Whitespace after timestamp bracket
-            [^:]+       # Author name (one or more characters that are NOT a colon)
-            :           # Colon after author
-            \s+         # Whitespace after colon
-        )
-        | # --- OR ---
-        # --- Option 2: Context block ANYWHERE in the string ---
-        (
-            \s*           # Optional leading whitespace before the block
-            <<context>>   # The literal opening tag
-            .*?           # Any character (including newline due to 's' flag), matched non-greedily
-            <</context>>  # The literal closing tag
-            \s*           # Optional trailing whitespace after the block
-        )
-        ",
-    )
-    .expect("Invalid regex for cleaning message")
-});
+// Message queue item for debouncing
+#[derive(Debug, Clone)]
+pub struct QueuedMessage {
+    message: Message,
+}
 
-const COMMON_SYSTEM_CONTEXT: &str = formatcp!(
-    r#"[CONTEXT]
-You are processing a sequence of Discord messages provided chronologically (oldest first).
-Each message object has a 'role' ('user' or 'assistant'). 'Assistant' messages are from the bot you are acting as or analyzing ("{DISCORD_BOT_NAME}"). This is IMPORTANT because it means if a message starts with [TIMESTAMP] {{{DISCORD_BOT_NAME}}}, the message IS FROM YOU YOURSELF. Use this information to avoid repeating what you've said or adjust behavior accordingly to align with what you've said, or continue responding to what you've left in the middle.
-Message content starts with metadata followed by the actual message:
-1.  An ISO 8601 timestamp in brackets (e.g., '[2023-10-27T10:30:00Z]').
-2.  The author's Discord username followed by a colon (e.g., 'JohnDoe: ').
-3.  The message text, potentially including fetched link content or image URLs.
-4.  Additional context within "<<context>>...<</context>>" tags, like bot mentions or reply info.
+// Agent session for persistent multi-turn conversations
+pub(crate) struct AgentSession {
+    agent: Agent<openai::CompletionModel>,
+    conversation_history: Vec<RigMessage>,
+    last_activity: Instant,
+}
 
-User message 'content' can be complex:
-- Simple text following metadata.
-- An array of text parts (each with metadata) and image URLs (`ImageUrl`).
-- Text parts may include fetched link content: '[Fetched Link Content: URL]...[End Fetched Link Content]'.
+impl AgentSession {
+    fn new(agent: Agent<openai::CompletionModel>, initial_history: Vec<RigMessage>) -> Self {
+        Self {
+            agent,
+            conversation_history: initial_history,
+            last_activity: Instant::now(),
+        }
+    }
 
-Interpret the full message content, considering timestamps, author, text, images, fetched links, and the <<context>> block. Use timestamps and authorship to gauge flow and relevance.
+    fn update_activity(&mut self) {
+        self.last_activity = Instant::now();
+    }
 
-**IMPORTANT**: If a user message mentions the bot and starts with '!', treat it as a potential command that might override standard behavior (e.g., "! be silent"). Factor this into your analysis/response."#
-);
+    fn add_messages(&mut self, messages: Vec<RigMessage>) {
+        self.conversation_history.extend(messages);
 
-const LAYER1_SYSTEM_PROMPT: &str = formatcp!(
-    r#"[ROLE] Discord Conversation Analyst
+        // Keep conversation history manageable - limit to 2x MESSAGE_CONTEXT_SIZE
+        let max_history = MESSAGE_CONTEXT_SIZE * 2;
+        if self.conversation_history.len() > max_history {
+            let excess = self.conversation_history.len() - max_history;
+            self.conversation_history.drain(0..excess);
+        }
+    }
 
-[TASK]
-Analyze the **final message** in the sequence. Evaluate if "{DISCORD_BOT_NAME}" should respond, considering the channel's casual, fun, friendly vibe. Consider:
--   Direct Engagement: Is the last message a question to the bot? Does it mention the bot? (Greatly increases response chance).
--   Relevance & Flow: Does it continue the immediate topic? Is it engaging?
--   Engagement Potential: Opportunity to add value, humor, or continue naturally?
--   Bot Activity: Was 'Assistant' the last/penultimate speaker? (Lean against responding unless directly engaged).
--   Information Value: Can a *brief* (1-2 sentence) interesting fact/perspective fit the vibe?
--   Context/Correction: Does the last message miss crucial context, contain errors (in a debate), or misunderstand concepts?
--   Humor Potential: Clear opportunity for witty/sarcastic comment on the *last message* or *current topic*?
--   Commands: Does the last message seem like a command to the bot (e.g., starting with '!' after mention)? Adjust score/decision accordingly.
+    fn is_expired(&self) -> bool {
+        self.last_activity.elapsed() > Duration::from_secs(AGENT_SESSION_TIMEOUT_MINS * 60)
+    }
+}
 
-Note: Avoid replying to yourself ('Assistant' as the last message). Detect irony/sarcasm.
-**CRITICAL:** Do not repeat or rephrase what have been said in the chat history. If the insight or humour topic is similar to what have been said in this chat, lower the score substantially.
+// Discord Send Message Tool
+#[derive(Debug, Clone)]
+struct DiscordSendMessageTool {
+    ctx: Arc<Context>,
+    channel_id: ChannelId,
+    reply_to_message_id: Option<u64>,
+}
 
-[OUTPUT FORMAT]
-You MUST output your analysis *only* in the following format, with each key on a new line. Do NOT add any other explanation or text. DO NOT output in the format of a user or assistant message (that is [timestamp] [author]: [message]), you MUST follow the format below:
-Insight: <One or two sentences for the potential insight, OR "None". Separate multiple insights with a semicolon.>
-HumorTopic: <Brief topic/idea for a joke relevant to the last message, OR "None". Separate multiple ideas with a semicolon. Lower the score below if this does not have enough potential to crack smiles, the bar is very high in the channel.>
-Score: <0-10 score reflecting need/opportunity. Increase for direct mentions. Decrease for commands like "be silent".>
-Respond: <"Yes" if score >= {RESPONSE_THRESHOLD} (or bot mentioned and score is not drastically lowered by a command), otherwise "No">
-"#
-);
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DiscordSendMessageArgs {
+    content: String,
+    #[serde(default)]
+    reply: bool,
+    /// Message ID to reply to (if reply is true). If not provided, replies to the most recent message.
+    #[serde(default)]
+    reply_to_message_id: Option<u64>,
+}
 
-fn generate_layer2_system_prompt(insight: Option<&str>, humor_topic: Option<&str>) -> String {
-    let task_guidance = match (humor_topic, insight) {
-        (_, Some(valuable_insight)) if valuable_insight != "None" => {
-            format!(r#"
-Your main goal is to briefly share this interesting point/perspective casually: '{}'. Ensure natural flow.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DiscordSendMessageOutput {
+    success: bool,
+    message_id: Option<u64>,
+    error: Option<String>,
+}
 
-[TONE & STYLE INSTRUCTIONS]
--   **BE YOUR PERSONA:** Witty, maybe ironic/sarcastic, be mean if necessary.
--   **Be Casual:** Natural language. Avoid formality, preaching, teaching unless that *is* the witty angle.
--   **Be Relevant:** Respond to the *latest* message(s), primarily the user message that triggered this response.
--   **Be Concise (usually):** Adapt length. Short/punchy often good, but detail is okay if needed. Match chat style (e.g., lowercase, slang).
--   **Use Markdown Subtly:** `*italic*`, `**bold**`, `` `code` `` sparingly. 1-2 relevant emojis okay."#, valuable_insight)
-        },
-        (Some(humour_topic), _) if humour_topic != "None" => {
-            format!(r#"
-Your main goal is to generate a witty, sarcastic, or funny response related to: '{}'. Keep it relevant to the latest message.
+#[derive(Debug, Error)]
+#[error("Discord send message error: {0}")]
+struct DiscordSendMessageError(String);
 
-[TONE & STYLE INSTRUCTIONS]
-• 1–2 sentences typically.
-• (Optional) End with 1-2 savage/ironic emoji.
-• References: memes, dev pains, pop culture sass, gen alpha brain rot etc. Feel free to be edgy/politically incorrect if contextually appropriate for a closed channel.
+impl Tool for DiscordSendMessageTool {
+    const NAME: &'static str = "send_discord_message";
+    type Error = DiscordSendMessageError;
+    type Args = DiscordSendMessageArgs;
+    type Output = DiscordSendMessageOutput;
 
-Sample Vibe Check Outputs (adapt beyond compsci):
--   "this code's got more memory leaks than your mama's weight bro 💀"
--   "these unit tests running slower than blizzard's sexual harassment investigations ⏳⚖️"
--   "this inheritance hierarchy more fucked up than elon's twitter algo 🌐🪓"
--   "who dereferenced null? must be that intern who still uses java 8 ☕️🧟"
--   "our pipeline more broken than crypto bros after ftx collapsed 💸📉""#, humour_topic)
-        },
-        _ => "Your main goal is to engage naturally with the latest message. Keep the conversation flowing fun and friendly. Be witty or add irony if appropriate.".to_string(),
-    };
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "send_discord_message".to_string(),
+            description: "Send a message to the Discord channel. Use this to respond to users."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "The message content to send"
+                    },
+                    "reply": {
+                        "type": "boolean",
+                        "description": "Whether to reply to a specific message (true) or send a standalone message (false)",
+                        "default": false
+                    },
+                    "reply_to_message_id": {
+                        "type": "number",
+                        "description": "The Discord message ID to reply to (only used when reply=true). If not provided when reply=true, will reply to the most recent message."
+                    }
+                },
+                "required": ["content"]
+            }),
+        }
+    }
 
-    format!(
-        r#"[PERSONA]
-You ARE the Discord bot "{DISCORD_BOT_NAME}". Witty, sarcastic, friendly, casual. Part of a fun, informal community.
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // Clone values to move into the spawned task
+        let ctx = self.ctx.clone();
+        let channel_id = self.channel_id;
+        let default_reply_to_message_id = self.reply_to_message_id;
+        let content = args.content.clone();
+        let reply = args.reply;
 
-[CONTEXT]
-You are seeing recent conversation history (User/Assistant messages) chronologically. Generate the *next* message as 'Assistant'. Remember, messages starting with "[TIMESTAMP] {DISCORD_BOT_NAME}:" are YOUR OWN previous messages in this sequence.
+        // Use the message ID from args if provided, otherwise fall back to default
+        let target_message_id = if reply {
+            args.reply_to_message_id.or(default_reply_to_message_id)
+        } else {
+            None
+        };
 
-[TASK GUIDANCE]
-**RESPONSE LENGTH & STOPPING:**
--   **DEFAULT TO ONE MESSAGE.** Your goal is almost always a single, concise response.
--   **Simple Inputs (e.g., "thanks", "ok", "lol", agreement): Respond ONCE briefly.** Do NOT elaborate or send multiple messages for simple social cues or acknowledgments.
--   **Multi-Message Exception (RARE):** ONLY consider a second message if the *first message* delivered complex information (like code, a detailed explanation) AND you have a *distinctly separate, highly valuable* follow-up point (like a crucial example or critical clarification) that could not fit reasonably in the first.
--   **NEVER send more than TWO messages.** The bar for a second message is extremely high.
--   **DO NOT REPEAT:** Absolutely avoid generating multiple messages that rephrase the same core idea, sentiment, or acknowledgment. If you or anyone else has said it, move on or stop.
+        // Spawn the Discord API operations in a separate task to avoid Sync issues
+        let handle = tokio::spawn(async move {
+            let mut message_builder = CreateMessage::new().content(&content);
 
-**ABSOLUTELY AVOID:**
--   Starting messages with phrases that just confirm understanding before providing the answer.
--   Generic AI sounds.
--   Being overly helpful/corrective unless witty.
--   Asking for confirmation.
+            if reply && target_message_id.is_some() {
+                if let Ok(original_msg) = channel_id
+                    .message(&ctx.http, target_message_id.unwrap())
+                    .await
+                {
+                    message_builder = message_builder.reference_message(&original_msg);
+                }
+            }
 
-**MULTI-MESSAGE FLOW (Use Sparingly):**
--   Your *first* message MUST contain the main point/answer.
--   **ONLY generate a second message IF you have a *distinctly new* angle, a relevant follow-up question, or a concrete example that significantly adds value beyond the first message.**
--   **DO NOT generate third or subsequent messages unless absolutely necessary to convey critical, distinct information that couldn't fit before.** The bar for continuing is VERY HIGH.
--   **CRITICAL: Avoid generating multiple messages that just rephrase, slightly alter, or elaborate on the *same core idea* or sentiment expressed in your previous message.** Each message needs *substantive novelty*.
--   **Prefer stopping early.** If in doubt, output "[END]". Output only "[END]" when you have nothing genuinely *new* and *valuable* to add. Never output "[END]" in a valid message, if you want to stop, output "[END]" in a new message.
+            channel_id.send_message(&ctx.http, message_builder).await
+        });
 
-{task_guidance}
+        match handle.await {
+            Ok(Ok(sent_message)) => {
+                tracing::debug!("Sent Discord message: {}", args.content);
+                Ok(DiscordSendMessageOutput {
+                    success: true,
+                    message_id: Some(sent_message.id.get()),
+                    error: None,
+                })
+            }
+            Ok(Err(e)) => {
+                tracing::error!("Failed to send Discord message: {}", e);
+                Ok(DiscordSendMessageOutput {
+                    success: false,
+                    message_id: None,
+                    error: Some(e.to_string()),
+                })
+            }
+            Err(e) => {
+                tracing::error!("Task join error while sending Discord message: {}", e);
+                Ok(DiscordSendMessageOutput {
+                    success: false,
+                    message_id: None,
+                    error: Some(format!("Task execution failed: {}", e)),
+                })
+            }
+        }
+    }
+}
 
-[STYLE - GEN Z]
-speak like a gen z. informal tone, slang, abbreviations, lowcaps often preferred. make it sound hip.
+// Fetch Page Content Tool
+#[derive(Debug, Clone)]
+struct FetchPageContentTool;
 
-example gen z slang:
-asl, based, basic, beat your face, bestie, bet, big yikes, boujee, bussin', clapback, dank, ded, drip, glow-up, goat., hits diff, ijbol, i oop, it's giving..., iykyk, let him cook, l+ratio, lit, moot/moots, npc, ok boomer, opp, out of pocket, period/perioduh, sheesh, shook, simp, situationship, sksksk, slaps, slay, soft-launch, stan, sus, tea, understood the assignment, valid, vibe check, wig, yeet
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FetchPageContentArgs {
+    url: String,
+}
 
-[OUTPUT INSTRUCTIONS]
-*   Output *only* the raw message content for Discord.
-*   NO "Assistant:", your name, or other prefixes/explanations.
-*   Just the chat message text. Use blank lines for separation if needed.
-*   Do NOT include the <<context>> block in the final response."#
-    )
-    .trim()
-    .into()
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FetchPageContentOutput {
+    content: String,
+    success: bool,
+    error: Option<String>,
+}
+
+#[derive(Debug, Error)]
+#[error("Fetch page content error: {0}")]
+struct FetchPageContentError(String);
+
+impl Tool for FetchPageContentTool {
+    const NAME: &'static str = "fetch_page_content";
+    type Error = FetchPageContentError;
+    type Args = FetchPageContentArgs;
+    type Output = FetchPageContentOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "fetch_page_content".to_string(),
+            description:
+                "Fetch and parse content from a web page URL. Returns the main content as text."
+                    .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "The URL to fetch content from"
+                    }
+                },
+                "required": ["url"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        match fetch_url_content_and_parse(&args.url).await {
+            Ok(content) => Ok(FetchPageContentOutput {
+                content,
+                success: true,
+                error: None,
+            }),
+            Err(e) => Ok(FetchPageContentOutput {
+                content: "[Failed to fetch content]".to_string(),
+                success: false,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
 }
 
 /// Fetches content from a URL, attempts to convert HTML to Markdown.
@@ -222,12 +286,12 @@ async fn fetch_url_content_and_parse(url_str: &str) -> Result<String, eyre::Erro
     }
 }
 
-/// Turn the discord chat history into LLM user and assistant messages.
-async fn build_history_messages(
+/// Build conversation history for agent context
+async fn build_conversation_history(
     ctx: &Context,
     channel_id: ChannelId,
     message_context_size: usize,
-) -> Result<Vec<ChatCompletionRequestMessage>, eyre::Error> {
+) -> Result<Vec<RigMessage>, eyre::Error> {
     let bot_user_id = ctx.cache.current_user().id;
 
     let fetched_messages: Vec<Message> = channel_id
@@ -240,399 +304,47 @@ async fn build_history_messages(
         .collect()
         .await;
 
-    let mut history_messages: Vec<ChatCompletionRequestMessage> =
-        Vec::with_capacity(fetched_messages.len());
+    let mut rig_messages = Vec::new();
 
     // Process messages chronologically (oldest first)
     for msg in fetched_messages.into_iter().rev() {
-        let author_name = &msg.author.name;
-        let is_bot_message = msg.author.id == bot_user_id;
-        let mentions_or_replies_to_bot = msg.mentions_user_id(bot_user_id)
-            || msg
-                .referenced_message
-                .as_ref()
-                .is_some_and(|m| m.author.id == bot_user_id);
-
-        let mut content_parts: Vec<ChatCompletionRequestUserMessageContentPart> = Vec::new();
-        let mut current_text = String::new();
-
-        // Start with metadata
-        // TODO: use relative time to emphasize time relevance.
-        let timestamp_str = msg.timestamp.to_rfc3339(); // Use standard format
-        current_text.push_str(&format!(
-            "[{}] {}: ",
-            timestamp_str.unwrap_or("N/A".into()),
-            author_name
-        ));
-
-        // Add main message content
-        current_text.push_str(&msg.content);
-
-        // Process attachments for images
-        for attachment in &msg.attachments {
-            if attachment
-                .content_type
-                .as_ref()
-                .is_some_and(|ct| ct.starts_with("image/"))
-            {
-                if !current_text.is_empty() {
-                    content_parts.push(ChatCompletionRequestUserMessageContentPart::Text(
-                        ChatCompletionRequestMessageContentPartText { text: current_text },
-                    ));
-
-                    // Reset for possible text after image like context and linked content
-                    current_text = String::new();
-                }
-                content_parts.push(ChatCompletionRequestUserMessageContentPart::ImageUrl(
-                    ChatCompletionRequestMessageContentPartImage {
-                        image_url: ImageUrl {
-                            url: attachment.proxy_url.clone(),
-                            detail: None, // Auto detail is usually fine
-                        },
-                    },
-                ));
-            }
-        }
-
-        let fetched_links_text = futures::stream::iter(
-            msg.content
-                .split_whitespace()
-                .map(ToString::to_string)
-                .filter(|word| word.starts_with("http://") || word.starts_with("https://")),
-        )
-        .map(|url| async move {
-            let result = fetch_url_content_and_parse(&url).await;
-            (url, result)
-        })
-        .buffered(1)
-        .filter_map(|(url, result)| async move {
-            match result {
-                Ok(md_content) if !md_content.is_empty() => Some(format!(
-                    "\n\n[Fetched Link Content: {}]\n{}\n[End Fetched Link Content]",
-                    url,
-                    md_content.trim()
-                )),
-                Ok(_) => {
-                    // Skip successfully fetched but empty content
-                    None
-                }
-                Err(e) => {
-                    tracing::warn!(url = %url, error = %e, "Failed to fetch or parse link content");
-                    Some(format!("\n[Could not fetch link: {}]", url))
-                }
-            }
-        })
-        .collect::<String>()
-        .await;
-
-        // Add context block, with fetched links inside <<context>>
-        let referenced_message_preview = msg
-            .referenced_message
-            .map(|m| {
-                let content_preview = if m.content.len() > MAX_REF_MSG_LEN {
-                    format!(
-                        "{}...",
-                        &m.content[..m
-                            .content
-                            .char_indices()
-                            .nth(MAX_REF_MSG_LEN)
-                            .map(|(n, _)| n)
-                            .unwrap_or(0)]
-                    )
-                } else {
-                    m.content
-                };
-                format!("{}: {}", m.author.name, content_preview)
-            })
-            .unwrap_or("None".into());
-
-        let context_block = if !fetched_links_text.is_empty() {
-            format!(
-                "\n\n<<context>>\n* Replied To: [{}]\n* Mentions/Replies Bot: [{}]\n{}\n<</context>>",
-                referenced_message_preview,
-                mentions_or_replies_to_bot,
-                fetched_links_text
-            )
-        } else {
-            format!(
-                "\n\n<<context>>\n* Replied To: [{}]\n* Mentions/Replies Bot: [{}]\n<</context>>",
-                referenced_message_preview, mentions_or_replies_to_bot
-            )
-        };
-        current_text.push_str(&context_block);
-
-        // Add any remaining text as the last part
-        if !current_text.is_empty() || content_parts.is_empty() {
-            // Ensure at least one part if no images
-            content_parts.push(ChatCompletionRequestUserMessageContentPart::Text(
-                ChatCompletionRequestMessageContentPartText { text: current_text },
-            ));
-        }
-
-        if is_bot_message {
-            // Combine text parts for Assistant messages (images from bot ignored for now)
-            let assistant_content = content_parts
-                .into_iter()
-                .filter_map(|part| match part {
-                    ChatCompletionRequestUserMessageContentPart::Text(t) => Some(t.text),
-                    _ => None, // Ignore images in bot's own history messages
-                })
-                .collect::<String>();
-
-            if !assistant_content.trim().is_empty() {
-                history_messages.push(
-                    ChatCompletionRequestAssistantMessageArgs::default()
-                        .content(assistant_content)
-                        .build()? // Handle potential build errors
-                        .into(),
-                );
-            }
-        } else {
-            history_messages.push(
-                ChatCompletionRequestUserMessageArgs::default()
-                    .content(content_parts)
-                    .build()?
-                    .into(),
-            );
-        }
+        let rig_message = discord_message_to_rig_message(&msg, bot_user_id);
+        rig_messages.push(rig_message);
     }
 
-    Ok(history_messages)
+    Ok(rig_messages)
 }
 
-/// Represents the parsed output of the Layer 1 analysis.
-#[derive(Debug, Default)]
-struct Layer1AnalysisResult {
-    score: i32,
-    insight: Option<String>,
-    humor_topic: Option<String>,
-    should_respond: bool,
-}
-
-/// Parses the structured output from the Layer 1 LLM call.
-fn parse_layer1_output(output: &str) -> Layer1AnalysisResult {
-    let mut result = Layer1AnalysisResult::default();
-
-    for line in output.lines() {
-        let trimmed_line = line.trim();
-
-        if trimmed_line.is_empty() {
-            continue;
-        }
-
-        // Split into key and value based on the first colon
-        if let Some((key, value)) = trimmed_line.split_once(':') {
-            let key = key.trim().to_ascii_lowercase();
-            let value_trimmed = value.trim();
-
-            match key.as_str() {
-                "score" => {
-                    result.score = value_trimmed.parse::<i32>().unwrap_or(0);
-                }
-                "insight" => {
-                    if !value_trimmed.is_empty()
-                        && !value_trimmed.to_ascii_lowercase().starts_with("none")
-                    {
-                        result.insight = Some(value_trimmed.to_string());
-                    }
-                }
-                "humortopic" => {
-                    if !value_trimmed.is_empty()
-                        && !value_trimmed.to_ascii_lowercase().starts_with("none")
-                    {
-                        result.humor_topic = Some(value_trimmed.to_string());
-                    }
-                }
-                "respond" => {
-                    result.should_respond = value_trimmed.to_ascii_lowercase().starts_with("yes");
-                }
-                k => {
-                    tracing::warn!(key = %k, "Unexpected key in Layer 1 output: {}", key);
-                }
-            }
-        } else {
-            tracing::warn!(%line, "Unexpected line format in Layer 1 output");
-        }
-    }
-
-    result
-}
-
-async fn handle_message(
-    openai_client: &OpenAIClient<OpenAIConfig>,
+/// The agentic message handler using rig with multi-turn support
+async fn handle_message_batch(
     ctx: Context,
-    msg: Message,
+    messages: Vec<QueuedMessage>,
+    handler: Arc<Handler>,
 ) -> Result<(), eyre::Error> {
-    // Ignore messages from the bot itself or from other bots
-    if msg.author.bot {
+    if messages.is_empty() {
         return Ok(());
     }
 
-    let base_history = build_history_messages(&ctx, msg.channel_id, MESSAGE_CONTEXT_SIZE).await?;
+    let channel_id = messages[0].message.channel_id;
 
-    let common_system_message: ChatCompletionRequestMessage =
-        ChatCompletionRequestSystemMessageArgs::default()
-            .content(COMMON_SYSTEM_CONTEXT)
-            .build()?
-            .into();
+    // Ensure we have an agent session for this channel with enough context to include recent messages
+    let context_size = std::cmp::max(MESSAGE_CONTEXT_SIZE, messages.len());
+    handler
+        .get_or_create_agent_session(&ctx, channel_id, context_size)
+        .await?;
 
-    // --- Layer 1: Analyze if Bot Should Respond ---
-    let layer1_system_message = ChatCompletionRequestSystemMessageArgs::default()
-        .content(LAYER1_SYSTEM_PROMPT)
-        .build()?
-        .into();
+    // Add the new messages to the agent's conversation and let it naturally respond
+    {
+        let mut sessions = handler.agent_sessions.lock().await;
+        if let Some(session) = sessions.get_mut(&channel_id) {
+            // Convert the batch of new messages to RigMessage format
+            let new_messages = queued_messages_to_rig_messages(&messages);
 
-    let mut layer1_messages = vec![common_system_message.clone(), layer1_system_message];
-    layer1_messages.extend(base_history.clone()); // Clone history for Layer 1
+            // Add new messages to the conversation history
+            session.add_messages(new_messages);
 
-    tracing::debug!(?layer1_messages, "layer 1 message");
-
-    let layer1_request = CreateChatCompletionRequestArgs::default()
-        .model(LAYER1_MODEL)
-        .messages(layer1_messages)
-        .max_tokens(LAYER1_MAX_TOKENS)
-        .temperature(LAYER1_TEMPERATURE)
-        .build()?;
-
-    let layer1_response = openai_client
-        .chat()
-        .create(layer1_request.clone())
-        .await
-        .wrap_err_with(|| format!("{:?}", &layer1_request))
-        .wrap_err("Failed to make layer 1 request")?;
-
-    let layer1_output_content = layer1_response
-        .choices
-        .first()
-        .and_then(|c| c.message.content.as_deref())
-        .unwrap_or("");
-
-    tracing::debug!(layer1_output_content, "layer 1 response");
-
-    let analysis_result = parse_layer1_output(layer1_output_content);
-
-    tracing::debug!(?analysis_result, "Parsed Layer 1 analysis result");
-
-    // --- Layer 2: Generate Response ---
-    if analysis_result.should_respond {
-        let _typing = Typing::start(ctx.http.clone(), msg.channel_id);
-
-        let layer2_system_prompt = generate_layer2_system_prompt(
-            analysis_result.insight.as_deref(),
-            analysis_result.humor_topic.as_deref(),
-        );
-        let layer2_system_message = ChatCompletionRequestSystemMessageArgs::default()
-            .content(layer2_system_prompt)
-            .build()?
-            .into();
-
-        let mut layer2_messages = vec![common_system_message, layer2_system_message];
-        layer2_messages.extend(base_history);
-
-        let mut is_first_response = true; // Flag to control replying vs sending
-        let mut response_message_count = 0;
-
-        'outer: loop {
-            if response_message_count >= MAX_ASSISTANT_RESPONSE_MESSAGE_COUNT {
-                tracing::debug!("Layer 2 message history exceeded limit, breaking loop.");
-                break;
-            }
-
-            if !is_first_response {
-                // Add a small delay to prevent rate limiting or flooding
-                tokio::time::sleep(Duration::from_millis(1000)).await;
-            }
-
-            let layer2_request = CreateChatCompletionRequestArgs::default()
-                .model(LAYER2_MODEL)
-                .messages(layer2_messages.clone())
-                .max_completion_tokens(25000u32) // including reasoning tokens
-                .n(1)
-                .reasoning_effort(ReasoningEffort::High)
-                // Commented due to not compatible with current model (prev: gpt-4.1)
-                // .max_tokens(LAYER2_MAX_TOKENS)
-                // .temperature(LAYER2_TEMPERATURE)
-                // .stop(["[END]".to_string()])
-                .build()?;
-
-            tracing::debug!(?layer2_request, "Layer 2 request");
-
-            let layer2_response = match openai_client.chat().create(layer2_request.clone()).await {
-                Ok(res) => res,
-                Err(e) => {
-                    tracing::error!(error = %e, ?layer2_request, "Layer 2 OpenAI API call failed during loop");
-                    break;
-                }
-            };
-
-            let assistant_response_content = layer2_response
-                .choices
-                .first()
-                .and_then(|c| c.message.content.as_deref())
-                .unwrap_or("")
-                .trim();
-
-            tracing::debug!(
-                raw_response = assistant_response_content,
-                "Layer 2 raw response in loop"
-            );
-
-            if assistant_response_content == "[END]" {
-                tracing::debug!("Received '[END]' signal. Terminating response generation.");
-                break;
-            }
-
-            let final_response = CLEAN_MESSAGE_REGEX
-                .replace_all(assistant_response_content, "")
-                .into_owned();
-
-            if final_response.is_empty() {
-                tracing::warn!("Layer 2 generated an empty response after cleaning (and not '[END]'). Stopping.");
-                break;
-            }
-
-            // Split the response into parts on blank lines (two newlines)
-            let parts: Vec<&str> = final_response
-                .split("\n\n")
-                .map(|part| part.trim())
-                .filter(|part| !part.is_empty())
-                .collect();
-
-            // Send each part as a separate message
-            for part in parts {
-                if part == "[END]" {
-                    tracing::debug!("Received '[END]' signal. Terminating response generation.");
-                    break 'outer;
-                }
-
-                let builder = if is_first_response {
-                    CreateMessage::new().reference_message(&msg).content(part)
-                } else {
-                    tokio::time::sleep(Duration::from_millis(part.len() as u64 * 20)).await;
-                    CreateMessage::new().content(part)
-                };
-
-                if let Err(e) = msg.channel_id.send_message(&ctx.http, builder).await {
-                    tracing::error!(error = %e, "Failed to send Layer 2 message part to Discord");
-                    break;
-                }
-
-                is_first_response = false;
-                response_message_count += 1;
-            }
-
-            // --- Update History for Next Iteration ---
-            let assistant_message = ChatCompletionRequestAssistantMessageArgs::default()
-                .content(format!(
-                    "[{}] {}: {}",
-                    chrono::Utc::now().to_rfc3339(),
-                    DISCORD_BOT_NAME,
-                    final_response
-                ))
-                .build()?
-                .into();
-
-            layer2_messages.push(assistant_message);
+            // Execute agent interaction with multi-turn reasoning
+            let _ = execute_agent_interaction(session, messages.len(), channel_id).await;
         }
     }
 
@@ -640,8 +352,140 @@ async fn handle_message(
 }
 
 pub struct Handler {
-    pub openai_client: OpenAIClient<OpenAIConfig>,
-    pub error_acked: AtomicBool,
+    pub message_queue: Arc<Mutex<HashMap<ChannelId, Vec<QueuedMessage>>>>,
+    pub openai_api_key: String,
+    /// Track pending timers for each channel to avoid duplicate processing
+    pub pending_timers: Arc<Mutex<HashMap<ChannelId, tokio::task::JoinHandle<()>>>>,
+    /// Persistent agent sessions per channel for multi-turn conversations
+    pub agent_sessions: Arc<Mutex<HashMap<ChannelId, AgentSession>>>,
+}
+
+impl Handler {
+    pub fn new(openai_api_key: String) -> Self {
+        Self {
+            message_queue: Arc::new(Mutex::new(HashMap::new())),
+            openai_api_key,
+            pending_timers: Arc::new(Mutex::new(HashMap::new())),
+            agent_sessions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Create a new Handler instance that shares the same underlying data
+    fn clone_for_task(&self) -> Arc<Self> {
+        Arc::new(Handler {
+            message_queue: self.message_queue.clone(),
+            openai_api_key: self.openai_api_key.clone(),
+            pending_timers: self.pending_timers.clone(),
+            agent_sessions: self.agent_sessions.clone(),
+        })
+    }
+
+    /// Get or create an agent session for a channel
+    async fn get_or_create_agent_session(
+        &self,
+        ctx: &Context,
+        channel_id: ChannelId,
+        context_size: usize,
+    ) -> Result<(), eyre::Error> {
+        let mut sessions = self.agent_sessions.lock().await;
+
+        // Check if session exists and is not expired
+        let needs_new_session = sessions
+            .get(&channel_id)
+            .is_none_or(|session| session.is_expired());
+
+        if needs_new_session {
+            // Create OpenAI client and build agent
+            let openai_client = openai::Client::new(&self.openai_api_key);
+
+            // Build conversation history for context
+            let history = build_conversation_history(ctx, channel_id, context_size).await?;
+
+            // Create tools with shared context
+            let ctx_arc = Arc::new(ctx.clone());
+            let discord_tool = DiscordSendMessageTool {
+                ctx: ctx_arc.clone(),
+                channel_id,
+                reply_to_message_id: None, // Will be set per interaction
+            };
+            let fetch_tool = FetchPageContentTool;
+
+            let agent = openai_client
+                .agent("o4-mini")
+                .preamble(SYSTEM_PROMPT)
+                .tool(discord_tool)
+                .tool(fetch_tool)
+                .additional_params(json!({
+                    "max_completion_tokens": 4096,
+                    "reasoning_effort": "high"
+                }))
+                .build();
+
+            // Store the history in the session rather than initializing the agent with it
+            tracing::debug!(
+                "Creating new agent session with {} messages of context",
+                history.len()
+            );
+
+            sessions.insert(channel_id, AgentSession::new(agent, history));
+        } else {
+            // Update activity timestamp
+            if let Some(session) = sessions.get_mut(&channel_id) {
+                session.update_activity();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Schedule processing for a channel after the debounce timeout
+    async fn schedule_channel_processing(&self, ctx: Context, channel_id: ChannelId) {
+        // Cancel any existing timer for this channel
+        {
+            let mut timers = self.pending_timers.lock().await;
+            if let Some(handle) = timers.remove(&channel_id) {
+                handle.abort();
+            }
+        }
+
+        // Create new timer
+        let message_queue = self.message_queue.clone();
+        let pending_timers = self.pending_timers.clone();
+        let handler = self.clone_for_task();
+
+        let handle = tokio::spawn(async move {
+            // Wait for the debounce timeout
+            tokio::time::sleep(Duration::from_millis(MESSAGE_DEBOUNCE_TIMEOUT_MS)).await;
+
+            // Remove this timer from pending list
+            {
+                let mut timers = pending_timers.lock().await;
+                timers.remove(&channel_id);
+            }
+
+            // Process the messages for this channel
+            let messages = {
+                let mut queue = message_queue.lock().await;
+                queue.remove(&channel_id).unwrap_or_default()
+            };
+
+            if !messages.is_empty() {
+                if let Err(e) = handle_message_batch(ctx, messages, handler).await {
+                    tracing::error!(
+                        "Error processing message batch for channel {}: {}",
+                        channel_id,
+                        e
+                    );
+                }
+            }
+        });
+
+        // Store the timer handle
+        {
+            let mut timers = self.pending_timers.lock().await;
+            timers.insert(channel_id, handle);
+        }
+    }
 }
 
 #[async_trait]
@@ -651,40 +495,283 @@ impl EventHandler for Handler {
             return;
         }
 
-        let chan_id = msg.channel_id;
-
-        if let Err(why) = handle_message(&self.openai_client, ctx.clone(), msg).await {
-            tracing::error!(error = ?why, "Error handling Discord message");
-
-            if !self.error_acked.load(std::sync::atomic::Ordering::Relaxed) {
-                self.error_acked
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-                let _ = chan_id
-                    .send_message(
-                        &ctx.http,
-                        CreateMessage::new().content(format!(
-                            "An error occurred while processing your message:\n```\n{:?}\n```",
-                            why
-                        )),
-                    )
-                    .await
-                    .inspect_err(|e| {
-                        tracing::error!(error = ?e, "Failed to send error message to Discord");
-                    });
-            }
-        } else {
-            self.error_acked
-                .compare_exchange(
-                    true,
-                    false,
-                    std::sync::atomic::Ordering::Relaxed,
-                    std::sync::atomic::Ordering::Relaxed,
-                )
-                .ok();
+        // Ignore messages from bots
+        if msg.author.bot {
+            return;
         }
+
+        // Add to queue
+        let queued_msg = QueuedMessage { message: msg };
+
+        let channel_id = queued_msg.message.channel_id;
+        {
+            let mut queue = self.message_queue.lock().await;
+            let channel_messages = queue.entry(channel_id).or_insert_with(Vec::new);
+            channel_messages.push(queued_msg);
+
+            // Limit queue size per channel
+            if channel_messages.len() > 10 {
+                channel_messages.remove(0);
+            }
+        }
+
+        // Schedule processing for this channel (this will reset the timer if one exists)
+        self.schedule_channel_processing(ctx, channel_id).await;
     }
 
     async fn ready(&self, _: Context, ready: Ready) {
         tracing::info!("Discord bot {} is connected!", ready.user.name);
     }
+}
+
+/// Helper function to format Discord message content with message ID, timestamp, and username
+fn format_message_content(msg: &Message) -> String {
+    const MAX_REF_MSG_LEN: usize = 100; // Maximum length for referenced message preview
+
+    let timestamp_str = msg.timestamp.to_rfc3339();
+    let author_name = &msg.author.name;
+    let message_id = msg.id.get();
+
+    // Check if message mentions the bot (we'll need the bot user ID for this)
+    // For now, we'll check if the message content contains the bot name
+    let mentions_bot = msg.content.contains(DISCORD_BOT_NAME)
+        || msg.content.contains("@") && msg.content.to_lowercase().contains("irony");
+
+    // Get referenced message preview
+    let referenced_message_preview = msg
+        .referenced_message
+        .as_ref()
+        .map(|m| {
+            let content_preview = if m.content.len() > MAX_REF_MSG_LEN {
+                format!(
+                    "{}...",
+                    &m.content[..m
+                        .content
+                        .char_indices()
+                        .nth(MAX_REF_MSG_LEN)
+                        .map(|(n, _)| n)
+                        .unwrap_or(0)]
+                )
+            } else {
+                m.content.clone()
+            };
+            format!("{}: {}", m.author.name, content_preview)
+        })
+        .unwrap_or_else(|| "None".to_string());
+
+    // Build context block
+    let context_block = format!(
+        "\n\n<<context>>\n* Replied To: [{}]\n* Mentions/Replies Bot: [{}]\n<</context>>",
+        referenced_message_preview, mentions_bot
+    );
+
+    let base_message = if msg.content.is_empty() && !msg.attachments.is_empty() {
+        // Handle attachments (images, files, etc.)
+        format!(
+            "[Message ID: {}] [{}] {}: [Attachment: {}]",
+            message_id,
+            timestamp_str.unwrap_or_else(|| "N/A".to_string()),
+            author_name,
+            msg.attachments
+                .iter()
+                .map(|a| a.filename.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    } else {
+        format!(
+            "[Message ID: {}] [{}] {}: {}",
+            message_id,
+            timestamp_str.unwrap_or_else(|| "N/A".to_string()),
+            author_name,
+            msg.content
+        )
+    };
+
+    format!("{}{}", base_message, context_block)
+}
+
+/// Helper function to convert a Discord message to a RigMessage
+fn discord_message_to_rig_message(
+    msg: &Message,
+    bot_user_id: serenity::model::id::UserId,
+) -> RigMessage {
+    let is_bot_message = msg.author.id == bot_user_id;
+
+    if is_bot_message {
+        // For bot messages, just use text content
+        let content = format_message_content(msg);
+        RigMessage::assistant(content)
+    } else {
+        // For user messages, handle both text and images
+        let mut has_images = false;
+        let mut content_parts = Vec::new();
+
+        // Add text content first
+        let text_content = format_message_content(msg);
+        content_parts.push(UserContent::text(text_content.clone()));
+
+        // Process attachments for images
+        for attachment in &msg.attachments {
+            if attachment
+                .content_type
+                .as_ref()
+                .is_some_and(|ct| ct.starts_with("image/"))
+            {
+                content_parts.push(UserContent::image(
+                    attachment.proxy_url.clone(),
+                    None,                    // format
+                    None,                    // media_type
+                    Some(ImageDetail::Auto), // detail level
+                ));
+                has_images = true;
+            }
+        }
+
+        if has_images {
+            match OneOrMany::many(content_parts) {
+                Ok(content) => RigMessage::from(content),
+                Err(_) => RigMessage::user(text_content), // Fallback to text-only if content list is empty
+            }
+        } else {
+            // If no images, just use the text content
+            RigMessage::user(text_content)
+        }
+    }
+}
+
+/// Helper function to convert a batch of QueuedMessages to RigMessages (all as user messages)
+fn queued_messages_to_rig_messages(messages: &[QueuedMessage]) -> Vec<RigMessage> {
+    messages
+        .iter()
+        .map(|queued_msg| {
+            let content = format_message_content(&queued_msg.message);
+            RigMessage::user(content)
+        })
+        .collect()
+}
+
+/// Create the system prompt for the Discord bot agent
+const SYSTEM_PROMPT: &str = formatcp!(
+    r#"[CONTEXT]
+You are processing a sequence of Discord messages provided chronologically (oldest first).
+Each message object has a 'role' ('user' or 'assistant'). 'Assistant' messages are from the bot you are acting as or analyzing ("{}"). This is IMPORTANT because it means if a message starts with [Message ID: xxx] [TIMESTAMP] {}, the message IS FROM YOU YOURSELF. Use this information to avoid repeating what you've said or adjust behavior accordingly to align with what you've said, or continue responding to what you've left in the middle.
+Message content starts with metadata followed by the actual message:
+1.  A Message ID in brackets (e.g., '[Message ID: 123456789]').
+2.  An ISO 8601 timestamp in brackets (e.g., '[2023-10-27T10:30:00Z]').
+3.  The author's Discord username followed by a colon (e.g., 'JohnDoe: ').
+4.  The message text, potentially including images.
+5.  Additional context within "<<context>>...<</context>>" tags, like bot mentions or reply info.
+
+Interpret the full message content, considering message IDs, timestamps, author, text, images, fetched links, and the <<context>> block. Use timestamps and authorship to gauge flow and relevance.
+
+**IMPORTANT**: If a user message mentions the bot and starts with '!', treat it as a potential command that might override standard behavior (e.g., "! be silent"). Factor this into your analysis/response.
+
+Each message in the conversation history includes its Discord message ID in the format "[Message ID: 123456789]".
+When you want to reply to a specific message, use that message ID in the reply_to_message_id parameter.
+
+[PERSONA]
+You ARE the Discord bot "{}". Witty, sarcastic, friendly, casual. Part of a fun, informal community.
+
+Only reply to messages that you find interesting, relevant, or that you can add value to. If a message is too basic, repetitive, or doesn't warrant a response, just ignore it. Don't feel obligated to reply to every message. For example, you can correct misinformation or add valueable insights to the ongoing conversation. Absolutely avoid being too spammy.
+
+[TASK GUIDANCE]
+**RESPONSE LENGTH & STOPPING:**
+-   **DEFAULT TO ONE MESSAGE.** Your goal is almost always a single, concise response.
+-   **Simple Inputs (e.g., "thanks", "ok", "lol", agreement): Respond ONCE briefly.** Do NOT elaborate or send multiple messages for simple social cues or acknowledgments.
+-   **Multi-Message Exception (RARE):** ONLY consider a second message if the *first message* delivered complex information (like code, a detailed explanation) AND you have a *distinctly separate, highly valuable* follow-up point (like a crucial example or critical clarification) that could not fit reasonably in the first.
+-   **DO NOT REPEAT:** Absolutely avoid generating multiple messages that rephrase the same core idea, sentiment, or acknowledgment. If you or anyone else has said it, move on or stop.
+
+**ABSOLUTELY AVOID:**
+-   Starting messages with phrases that just confirm understanding before providing the answer.
+-   Generic AI sounds.
+-   Being overly helpful/corrective unless witty.
+-   Asking for confirmation.
+
+**MULTI-MESSAGE FLOW (Use Sparingly):**
+-   Your *first* message MUST contain the main point/answer.
+-   **ONLY generate a second message IF you have a *distinctly new* angle, a relevant follow-up question, or a concrete example that significantly adds value beyond the first message.**
+-   **DO NOT generate third or subsequent messages unless absolutely necessary to convey critical, distinct information that couldn't fit before.** The bar for continuing is VERY HIGH.
+-   **CRITICAL: Avoid generating multiple messages that just rephrase, slightly alter, or elaborate on the *same core idea* or sentiment expressed in your previous message.** Each message needs *substantive novelty*.
+-   **Prefer stopping early.** If in doubt, don't send additional messages. Never send follow-up messages that just rephrase or slightly expand on what you already said.
+
+**CRITICAL:** Do not repeat or rephrase what have been said in the chat history. If the insight or humour topic is similar to what have been said in this chat, avoid responding unless you have something genuinely new to add.
+
+[TONE & STYLE INSTRUCTIONS]
+-   **BE YOUR PERSONA:** Witty, maybe ironic/sarcastic, be mean if necessary.
+-   **Be Casual:** Natural language. Avoid formality, preaching, teaching unless that *is* the witty angle.
+-   **Be Relevant:** Respond to the *latest* message(s), primarily the user message that triggered this response.
+-   **Be Concise (usually):** Adapt length. Short/punchy often good, but detail is okay if needed. Match chat style (e.g., lowercase, slang).
+-   **Use Markdown Subtly:** `*italic*`, `**bold**`, `` `code` `` sparingly. 1-2 relevant emojis okay.
+
+[STYLE - GEN Z]
+speak like a gen z. informal tone, slang, abbreviations, lowcaps often preferred. make it sound hip.
+
+example gen z slang:
+asl, based, basic, beat your face, bestie, bet, big yikes, boujee, bussin', clapback, dank, ded, drip, glow-up, goat., hits diff, ijbol, i oop, it's giving..., iykyk, let him cook, l+ratio, lit, moot/moots, npc, ok boomer, opp, out of pocket, period/perioduh, sheesh, shook, simp, situationship, sksksk, slaps, slay, soft-launch, stan, sus, tea, understood the assignment, valid, vibe check, wig, yeet
+
+[TOOLS AVAILABLE]
+You have access to tools that let you:
+- Send messages to Discord (send_discord_message) - use with reply=false for standalone messages, reply=true or reply_to_message_id=<message_id> to reply to recent messages
+- Fetch web page content when needed (fetch_page_content)
+
+You can use multi-turn reasoning to:
+- Fetch URL content and then provide thoughtful analysis
+- Send multiple messages to build a complete response (but prefer single messages)
+- Chain multiple tool calls together for complex tasks
+
+[OUTPUT INSTRUCTIONS]
+- Use tools to send Discord messages - don't output raw text
+- When sending Discord messages, you can reply to recent messages by setting reply=true (the system will automatically determine which message to reply to based on context)
+- Be strategic about when to respond - add value or humor to the conversation
+- Remember previous interactions in this channel for better continuity"#,
+    DISCORD_BOT_NAME,
+    DISCORD_BOT_NAME,
+    DISCORD_BOT_NAME
+);
+
+/// Helper to execute agent multi-turn reasoning and handle the response
+async fn execute_agent_interaction(
+    session: &mut AgentSession,
+    messages_count: usize,
+    channel_id: ChannelId,
+) -> Result<(), eyre::Error> {
+    if session.conversation_history.is_empty() {
+        return Ok(());
+    }
+
+    let mut history_clone = session.conversation_history.clone();
+    match session
+        .agent
+        .prompt("")
+        .with_history(&mut history_clone)
+        .multi_turn(MAX_AGENT_TURNS)
+        .await
+    {
+        Ok(response) => {
+            tracing::debug!(
+                "Agent processed {} new messages for channel {}: {}",
+                messages_count,
+                channel_id,
+                response
+            );
+
+            // Add the agent's response to the conversation history
+            session
+                .conversation_history
+                .push(RigMessage::assistant(response));
+        }
+        Err(e) => {
+            tracing::error!(
+                "Agent error processing {} messages for channel {}: {}",
+                messages_count,
+                channel_id,
+                e
+            );
+            return Err(e.into());
+        }
+    }
+
+    session.update_activity();
+    Ok(())
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -9,12 +9,7 @@ use config::ServerConfig;
 use dotenv::dotenv;
 use mimalloc::MiMalloc;
 use serde_json::json;
-use std::{
-    net::SocketAddr,
-    ops::Deref,
-    sync::{atomic::AtomicBool, Arc},
-    time::Duration,
-};
+use std::{net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 use tower_http::{
     classify::ServerErrorsFailureClass,
     cors::{AllowOrigin, CorsLayer},
@@ -220,8 +215,8 @@ async fn start_discord_service(config: ServerConfig) -> Result<(), eyre::Error> 
             | GatewayIntents::MESSAGE_CONTENT;
 
         // Create OpenAI client with async-openai
-        let config = OpenAIConfig::new().with_api_key(openai_api_key);
-        let openai_client = OpenAIClient::with_config(config).with_http_client(
+        let config = OpenAIConfig::new().with_api_key(&openai_api_key);
+        let _openai_client = OpenAIClient::with_config(config).with_http_client(
             reqwest::Client::builder()
                 .timeout(Duration::from_secs(120))
                 .build()?,
@@ -230,10 +225,7 @@ async fn start_discord_service(config: ServerConfig) -> Result<(), eyre::Error> 
         // Create a new instance of the Client, logging in as a bot. This will automatically prepend
         // your bot token with "Bot ", which is a requirement by Discord for bot users.
         let mut discord_client = serenity::Client::builder(&discord_token, intents)
-            .event_handler(discord::bot::Handler {
-                openai_client,
-                error_acked: AtomicBool::new(false),
-            })
+            .event_handler(discord::bot::Handler::new(openai_api_key.clone()))
             .await
             .map_err(|e| eyre::eyre!("Error creating Discord client: {e:?}"))?;
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
               # article-scraper rust
               libxml2
               openssl
+              postgresql
             ];
 
             shellHook = if system == "x86_64-linux" then prisma.shellHook else "";


### PR DESCRIPTION
Replace the old two-layer OpenAI implementation with rig-core's agent framework for better multi-turn reasoning and tool integration. Key changes:

- Add rig-core dependency for agent-based LLM interactions
- Implement message debouncing to batch rapid messages
- Create persistent agent sessions per channel with conversation history
- Add Discord send message and page content fetching tools
- Use o4-mini model with high reasoning effort for better responses
- Support multi-turn agent reasoning with configurable turn limits
- Maintain conversation context and handle session timeouts
- Simplify message processing with agent-driven tool usage

The new architecture provides more sophisticated conversation handling and better integration between web content fetching and Discord messaging through the agent's tool system.

Co-authored-by: @claude